### PR TITLE
feat(ui): Add main, sub, and top navigation sections for admin layout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ yarn-error.log*
 # Misc
 .DS_Store
 *.pem
+
+# Devfolder
+/apps/devapp

--- a/apps/devapp/app/(admin)/dashboard/page.tsx
+++ b/apps/devapp/app/(admin)/dashboard/page.tsx
@@ -1,11 +1,5 @@
 "use client";
 
-import { Container, Grid, Paper, SimpleGrid, Stack, Text } from "@mantine/core";
-
 export default function () {
-  return (
-    <>
-      
-    </>
-  );
+  return <>Dashboard</>;
 }

--- a/apps/devapp/app/(admin)/dashboard/page.tsx
+++ b/apps/devapp/app/(admin)/dashboard/page.tsx
@@ -1,5 +1,20 @@
 "use client";
 
+import { useEffect } from "react";
+import { useBreadcrumbContext } from "../../../../../packages/ui/src/context/BreadcrumbContext";
+
 export default function () {
+  const { setBreadcrumbs } = useBreadcrumbContext();
+  useEffect(() => {
+    setBreadcrumbs([
+      { label: "Rag" },
+      { label: "Shy" },
+      { label: "Nix" },
+      { label: "Echo" },
+      { label: "Regs" },
+    ]);
+
+    return () => setBreadcrumbs(null);
+  }, []);
   return <>Dashboard</>;
 }

--- a/apps/devapp/config/nav/modules.tsx
+++ b/apps/devapp/config/nav/modules.tsx
@@ -6,6 +6,10 @@ import {
   UsersIcon,
   UserGearIcon,
   GearIcon,
+  ShieldCheckIcon,
+  FileTextIcon,
+  NoteBlankIcon,
+  ImageIcon,
 } from "@phosphor-icons/react";
 import { _nav as navMain } from "./nav_main";
 import { NavItem } from "../../../../packages/ui/src/layouts/AdminShell/AdminShell.type";
@@ -32,6 +36,7 @@ export const links: NavItem[] = [
     children: [
       {
         label: "Dashboards",
+        roles: ["admin"],
         children: [
           {
             label: "User Dashboard",
@@ -44,12 +49,65 @@ export const links: NavItem[] = [
             url: "/settings",
             roles: ["admin"],
           },
-          { horizontalLine: true, roles: ["admin"] },
+          {
+            label: "Admin Dashboard",
+            roles: ["admin"],
+            children: [
+              {
+                label: "Admin Dashboard",
+                url: "/admin",
+                roles: ["admin"],
+              },
+              {
+                label: "Admin Settings",
+                url: "/admin/settings",
+                roles: ["admin"],
+              },
+              {
+                label: "Advanced",
+                roles: ["admin"],
+                children: [
+                  {
+                    label: "System Logs",
+                    url: "/admin/system/logs",
+                    roles: ["admin"],
+                  },
+                  {
+                    label: "Audit Trail",
+                    url: "/admin/system/audit",
+                    roles: ["admin"],
+                  },
+                  {
+                    label: "Security",
+                    roles: ["admin"],
+                    children: [
+                      {
+                        label: "Firewall Settings",
+                        url: "/admin/security/firewall",
+                        roles: ["admin"],
+                      },
+                      {
+                        label: "IP Whitelist",
+                        url: "/admin/security/ip",
+                        roles: ["admin"],
+                      },
+                      {
+                        label: "Session Management",
+                        url: "/admin/security/session",
+                        roles: ["admin"],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
         ],
-        roles: ["admin"],
       },
+      { horizontalLine: true, roles: ["admin"] },
       {
         label: "Reports",
+        roles: ["admin"],
         children: [
           {
             label: "Sale Reports",
@@ -61,8 +119,39 @@ export const links: NavItem[] = [
             url: "/dashboard/reports/invoice",
             roles: ["admin"],
           },
+          {
+            label: "Analytics",
+            roles: ["admin"],
+            children: [
+              {
+                label: "Traffic",
+                url: "/dashboard/reports/analytics/traffic",
+                roles: ["admin"],
+              },
+              {
+                label: "Engagement",
+                url: "/dashboard/reports/analytics/engagement",
+                roles: ["admin"],
+              },
+              {
+                label: "Conversions",
+                roles: ["admin"],
+                children: [
+                  {
+                    label: "By Product",
+                    url: "/dashboard/reports/analytics/conversions/product",
+                    roles: ["admin"],
+                  },
+                  {
+                    label: "By Region",
+                    url: "/dashboard/reports/analytics/conversions/region",
+                    roles: ["admin"],
+                  },
+                ],
+              },
+            ],
+          },
         ],
-        roles: ["admin"],
       },
       {
         label: "Messages",
@@ -74,33 +163,5 @@ export const links: NavItem[] = [
         roles: ["admin"],
       },
     ],
-  },
-  {
-    label: "Users",
-    description: "Manage users",
-    icon: <UsersIcon size={24} />,
-    url: "/users",
-    roles: ["admin"],
-    children: [
-      {
-        label: "All Users",
-        url: "/users/all",
-        icon: <UsersIcon size={24} />,
-        roles: ["admin"],
-      },
-      {
-        label: "Admins",
-        url: "/users/admin",
-        icon: <UserGearIcon size={24} />,
-        roles: ["admin"],
-      },
-    ],
-  },
-  {
-    label: "Settings",
-    description: "Settings for admin users",
-    icon: <GearIcon size={24} />,
-    url: "/settings",
-    roles: ["admin"],
   },
 ];

--- a/apps/devapp/config/nav/modules.tsx
+++ b/apps/devapp/config/nav/modules.tsx
@@ -1,4 +1,14 @@
+import { Indicator } from "@mantine/core";
+import {
+  HouseIcon,
+  CakeIcon,
+  ChatCircleDotsIcon,
+  UsersIcon,
+  UserGearIcon,
+  GearIcon,
+} from "@phosphor-icons/react";
 import { _nav as navMain } from "./nav_main";
+import { NavItem } from "../../../../packages/ui/src/layouts/AdminShell/AdminShell.type";
 
 export const navs = {
   navMain,
@@ -9,5 +19,88 @@ export const navModules = [
     label: "General",
     url: "/",
     subModules: navMain,
+  },
+];
+
+export const links: NavItem[] = [
+  {
+    label: "Dashboard",
+    description: "Dashboard for admin & users",
+    icon: <HouseIcon size={24} />,
+    url: "/dashboard",
+    roles: ["admin", "guest", "user"],
+    children: [
+      {
+        label: "Dashboards",
+        children: [
+          {
+            label: "User Dashboard",
+            url: "/user",
+            customRender: <CakeIcon size={24} />,
+            roles: ["admin"],
+          },
+          {
+            label: "Settings",
+            url: "/settings",
+            roles: ["admin"],
+          },
+          { horizontalLine: true, roles: ["admin"] },
+        ],
+        roles: ["admin"],
+      },
+      {
+        label: "Reports",
+        children: [
+          {
+            label: "Sale Reports",
+            url: "/dashboard/reports/sales",
+            roles: ["admin"],
+          },
+          {
+            label: "Invoice Reports",
+            url: "/dashboard/reports/invoice",
+            roles: ["admin"],
+          },
+        ],
+        roles: ["admin"],
+      },
+      {
+        label: "Messages",
+        url: "/messages",
+        icon: <ChatCircleDotsIcon size={24} />,
+        customRender: (
+          <Indicator label="2" color="brand" size="lg" radius="xl" />
+        ),
+        roles: ["admin"],
+      },
+    ],
+  },
+  {
+    label: "Users",
+    description: "Manage users",
+    icon: <UsersIcon size={24} />,
+    url: "/users",
+    roles: ["admin"],
+    children: [
+      {
+        label: "All Users",
+        url: "/users/all",
+        icon: <UsersIcon size={24} />,
+        roles: ["admin"],
+      },
+      {
+        label: "Admins",
+        url: "/users/admin",
+        icon: <UserGearIcon size={24} />,
+        roles: ["admin"],
+      },
+    ],
+  },
+  {
+    label: "Settings",
+    description: "Settings for admin users",
+    icon: <GearIcon size={24} />,
+    url: "/settings",
+    roles: ["admin"],
   },
 ];

--- a/apps/devapp/config/theme/theme.mantine.main.tsx
+++ b/apps/devapp/config/theme/theme.mantine.main.tsx
@@ -1,18 +1,22 @@
+import { colorsTuple } from "@mantine/core";
+
 export const configThemeMantineMain: any = {
   // * COLORS & SHADES
   colors: {
     brand: [
-      "#f4f5fb", // 50
-      "#e8eaf6", // 100
-      "#cbd4ec", // 200
-      "#9eafdb", // 300
-      "#6a85c6", // 400
-      "#4765b0", // 500
-      "#354e94", // 600
-      "#2c3f78", // 700
-      "#283764", // 800
-      "#263154", // 900
+      "#ebaeb1", // 50
+      "#e69a9d", // 100
+      "#e08589", // 200
+      "#db7176", // 300
+      "#d65d62", // 400
+      "#d1484f", // 500
+      "#cc343b", // 600
+      "#b82f35", // 700
+      "#a32a2f", // 800
+      "#8f2429", // 900
     ],
+    backgroundPrimary: colorsTuple("#242424"),
+    backgroundDeep: colorsTuple("#1A1A1A"),
   },
   primaryColor: "brand",
   primaryShade: {

--- a/apps/devapp/layouts/admin/index.tsx
+++ b/apps/devapp/layouts/admin/index.tsx
@@ -1,11 +1,14 @@
-import { navs } from "@/config/nav/modules";
+"use client";
+import { links, navs } from "@/config/nav/modules";
 import { Container } from "@mantine/core";
 import { AdminShell } from "@vkit/ui";
 
 export function LayoutAdmin({ children }: any) {
   return (
     <>
-      <AdminShell navItems={navs}>{children}</AdminShell>
+      <AdminShell navItems={links} logo="/logo1.png" appTitle="Hami Nepal">
+        {children}
+      </AdminShell>
     </>
   );
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,8 +49,8 @@
         "@mantine/nprogress": "^8.1.1",
         "@mantine/spotlight": "^8.1.1",
         "@mantine/tiptap": "^8.1.1",
-        "@nyx/core": "*",
-        "@nyx/ui": "*",
+        "@vkit/core": "*",
+        "@vkit/ui": "*",
         "@phosphor-icons/react": "^2.1.10",
         "@tanstack/react-query": "^5.80.7",
         "@tiptap/extension-link": "^2.14.0",
@@ -1355,11 +1355,11 @@
         "node": ">= 8"
       }
     },
-    "node_modules/@nyx/core": {
+    "node_modules/@vkit/core": {
       "resolved": "packages/core",
       "link": true
     },
-    "node_modules/@nyx/ui": {
+    "node_modules/@vkit/ui": {
       "resolved": "packages/ui",
       "link": true
     },
@@ -9176,7 +9176,7 @@
       }
     },
     "packages/core": {
-      "name": "@nyx/core",
+      "name": "@vkit/core",
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
@@ -9218,7 +9218,7 @@
       "license": "MIT"
     },
     "packages/ui": {
-      "name": "@nyx/ui",
+      "name": "@vkit/ui",
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,14 +49,14 @@
         "@mantine/nprogress": "^8.1.1",
         "@mantine/spotlight": "^8.1.1",
         "@mantine/tiptap": "^8.1.1",
-        "@vkit/core": "*",
-        "@vkit/ui": "*",
         "@phosphor-icons/react": "^2.1.10",
         "@tanstack/react-query": "^5.80.7",
         "@tiptap/extension-link": "^2.14.0",
         "@tiptap/pm": "^2.14.0",
         "@tiptap/react": "^2.14.0",
         "@tiptap/starter-kit": "^2.14.0",
+        "@vkit/core": "*",
+        "@vkit/ui": "*",
         "axios": "^1.10.0",
         "dayjs": "^1.11.13",
         "embla-carousel": "^8.6.0",
@@ -1355,14 +1355,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/@vkit/core": {
-      "resolved": "packages/core",
-      "link": true
-    },
-    "node_modules/@vkit/ui": {
-      "resolved": "packages/ui",
-      "link": true
-    },
     "node_modules/@phosphor-icons/react": {
       "version": "2.1.10",
       "resolved": "https://registry.npmjs.org/@phosphor-icons/react/-/react-2.1.10.tgz",
@@ -2392,6 +2384,18 @@
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       }
+    },
+    "node_modules/@vkit/core": {
+      "resolved": "packages/core",
+      "link": true
+    },
+    "node_modules/@vkit/ui": {
+      "resolved": "packages/ui",
+      "link": true
+    },
+    "node_modules/@vkitnyx/ui": {
+      "resolved": "packages/ui",
+      "link": true
     },
     "node_modules/acorn": {
       "version": "8.15.0",
@@ -9218,7 +9222,7 @@
       "license": "MIT"
     },
     "packages/ui": {
-      "name": "@vkit/ui",
+      "name": "@vkitnyx/ui",
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@nyx/core",
+  "name": "@vkit/core",
   "version": "1.0.0",
   "main": "index.js",
   "scripts": {

--- a/packages/core/src/helpers/apiDispatch/apiDispatch.ts
+++ b/packages/core/src/helpers/apiDispatch/apiDispatch.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import axios from "axios";
-import { triggerNotification } from "@nyx/ui";
+import { triggerNotification } from "@vkit/ui";
 
 async function handleTokenExpiry() {
   const res = await axios

--- a/packages/core/src/helpers/moduleApiCall/index.ts
+++ b/packages/core/src/helpers/moduleApiCall/index.ts
@@ -1,4 +1,4 @@
-import { apiDispatch } from "@nyx/core";
+import { apiDispatch } from "@vkit/core";
 
 async function getRecords({
   endpoint,

--- a/packages/core/src/wrappers/DataTableWrapper/DataTableWrapper.tsx
+++ b/packages/core/src/wrappers/DataTableWrapper/DataTableWrapper.tsx
@@ -6,7 +6,7 @@ import {
   useDataTableContext,
   DataTableContext,
 } from "./DataTableWrapper.context";
-import { autoSearch } from "@nyx/core";
+import { autoSearch } from "@vkit/core";
 import { useDataTableWrapperStore } from "./DataTableWrapper.store";
 import { PropDataTableWrapper } from "./DataTableWrapper.type";
 

--- a/packages/core/src/wrappers/FormWrapper/FormWrapper.tsx
+++ b/packages/core/src/wrappers/FormWrapper/FormWrapper.tsx
@@ -6,7 +6,7 @@ import { useFormWrapperStore } from "./FormWrapper.store";
 //react-query
 import { useMutation } from "@tanstack/react-query";
 //helpers
-import { formatJsonSubmit } from "@nyx/core";
+import { formatJsonSubmit } from "@vkit/core";
 import { formWrapperErrorHandler } from "./FormWrapper.errorhandleer";
 //context
 import {

--- a/packages/core/src/wrappers/PreferenceWrapper/PreferenceWrapper.tsx
+++ b/packages/core/src/wrappers/PreferenceWrapper/PreferenceWrapper.tsx
@@ -2,7 +2,7 @@
 
 import React, { useEffect, useCallback, useMemo } from "react";
 import Cookies from "js-cookie";
-import { usePreferences } from "@nyx/core";
+import { usePreferences } from "@vkit/core";
 //props
 import { PropPreferenceWrapper } from "./PreferenceWrapper.type";
 

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@nyx/ui",
+  "name": "@vkitnyx/ui",
   "version": "1.0.0",
   "main": "index.js",
   "scripts": {

--- a/packages/ui/src/context/BreadcrumbContext.tsx
+++ b/packages/ui/src/context/BreadcrumbContext.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import React, { createContext, useContext, useState } from "react";
+
+export type Crumb = { label: string; href?: string };
+
+const BreadcrumbContext = createContext<{
+  breadcrumbs: Crumb[] | null;
+  setBreadcrumbs: (crumbs: Crumb[] | null) => void;
+}>({
+  breadcrumbs: null,
+  setBreadcrumbs: () => {},
+});
+
+export const BreadcrumbProvider = ({
+  children,
+}: {
+  children: React.ReactNode;
+}) => {
+  const [breadcrumbs, setBreadcrumbs] = useState<Crumb[] | null>(null);
+
+  return (
+    <BreadcrumbContext.Provider value={{ breadcrumbs, setBreadcrumbs }}>
+      {children}
+    </BreadcrumbContext.Provider>
+  );
+};
+
+export const useBreadcrumbContext = () => useContext(BreadcrumbContext);

--- a/packages/ui/src/hooks/useBreadcrumbs.ts
+++ b/packages/ui/src/hooks/useBreadcrumbs.ts
@@ -1,0 +1,35 @@
+import { usePathname } from "next/navigation";
+import { NavItem } from "../layouts/AdminShell/AdminShell.type";
+
+export function useBreadcrumbs(links: NavItem[]) {
+  const pathname = usePathname();
+
+  const result: { label: string; href?: string }[] = [];
+
+  const findPath = (
+    items: NavItem[],
+    parentTrail: { label: string; href?: string }[] = []
+  ): boolean => {
+    for (const item of items) {
+      if (!item.label) continue;
+      const currentTrail = [
+        ...parentTrail,
+        { label: item.label, href: item.url },
+      ];
+
+      if (pathname === item.url) {
+        result.push(...currentTrail);
+        return true;
+      }
+
+      if (item.children && findPath(item.children, currentTrail)) {
+        return true;
+      }
+    }
+    return false;
+  };
+
+  findPath(links);
+
+  return result;
+}

--- a/packages/ui/src/layouts/AdminShell/AdminShell.tsx
+++ b/packages/ui/src/layouts/AdminShell/AdminShell.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Container, Flex, Group } from "@mantine/core";
+import { Box, Container, Flex, Group } from "@mantine/core";
 //components
 import { AdminShellMainnav } from "./components/MainNav";
 import { AdminShellSubnav } from "./components/SubNav";
@@ -8,6 +8,8 @@ import { AdminShellSubnav } from "./components/SubNav";
 //type
 import { NavItem, PropAdminShell } from "./AdminShell.type";
 import { usePathname } from "next/navigation";
+import { AdminShellTopnav } from "./components/Topnav/AdminShell.Topnav";
+import { BreadcrumbProvider } from "../../context/BreadcrumbContext";
 
 export function AdminShell({
   navItems,
@@ -38,23 +40,35 @@ export function AdminShell({
   const subLinks = active?.children || [];
   return (
     <>
-      <Flex>
-        <nav>
-          <Group gap={0} visibleFrom="md">
-            <AdminShellMainnav
-              logo={logo}
+      <BreadcrumbProvider>
+        <Flex>
+          <nav>
+            <Group gap={0} visibleFrom="md">
+              <AdminShellMainnav
+                logo={logo}
+                navItems={navItems}
+                appTitle={appTitle}
+              />
+              <AdminShellSubnav
+                navItems={subLinks}
+                appTitle={appTitle}
+                active={active || ({} as NavItem)}
+              />
+            </Group>
+          </nav>
+          <Flex direction="column" flex={1}>
+            <AdminShellTopnav
+              actions={actions}
+              moduleName={active?.label ?? ""}
               navItems={navItems}
-              appTitle={appTitle}
-            />
-            <AdminShellSubnav
-              navItems={subLinks}
+              logo={logo}
               appTitle={appTitle}
               active={active || ({} as NavItem)}
             />
-          </Group>
-        </nav>
-        {children}
-      </Flex>
+            <Box p="md">{children}</Box>
+          </Flex>
+        </Flex>
+      </BreadcrumbProvider>
     </>
   );
 }

--- a/packages/ui/src/layouts/AdminShell/AdminShell.tsx
+++ b/packages/ui/src/layouts/AdminShell/AdminShell.tsx
@@ -1,11 +1,13 @@
 "use client";
 
-import { Container, Flex } from "@mantine/core";
+import { Container, Flex, Group } from "@mantine/core";
 //components
 import { AdminShellMainnav } from "./components/MainNav";
+import { AdminShellSubnav } from "./components/SubNav";
 
 //type
-import { PropAdminShell } from "./AdminShell.type";
+import { NavItem, PropAdminShell } from "./AdminShell.type";
+import { usePathname } from "next/navigation";
 
 export function AdminShell({
   navItems,
@@ -14,15 +16,42 @@ export function AdminShell({
   appTitle,
   children,
 }: PropAdminShell) {
+  const pathname = usePathname();
+
+  const findActiveParent = (
+    links: NavItem[],
+    pathname: string
+  ): NavItem | undefined => {
+    for (const link of links) {
+      if (link.url && pathname.startsWith(link.url)) {
+        if (link.children) {
+          const childMatch = findActiveParent(link.children, pathname);
+          if (childMatch) return link;
+        }
+        return link;
+      }
+    }
+    return undefined;
+  };
+
+  const active = findActiveParent(navItems, pathname);
+  const subLinks = active?.children || [];
   return (
     <>
       <Flex>
         <nav>
-          <AdminShellMainnav
-            logo={logo}
-            navItems={navItems}
-            appTitle={appTitle}
-          />
+          <Group gap={0} visibleFrom="md">
+            <AdminShellMainnav
+              logo={logo}
+              navItems={navItems}
+              appTitle={appTitle}
+            />
+            <AdminShellSubnav
+              navItems={subLinks}
+              appTitle={appTitle}
+              active={active || ({} as NavItem)}
+            />
+          </Group>
         </nav>
         {children}
       </Flex>

--- a/packages/ui/src/layouts/AdminShell/AdminShell.tsx
+++ b/packages/ui/src/layouts/AdminShell/AdminShell.tsx
@@ -1,22 +1,31 @@
 "use client";
 
-import { Container } from "@mantine/core";
+import { Container, Flex } from "@mantine/core";
 //components
+import { AdminShellMainnav } from "./components/MainNav";
 
-import { AdminShellTopnav } from "./components/Topnav/index";
 //type
 import { PropAdminShell } from "./AdminShell.type";
 
 export function AdminShell({
   navItems,
-  classNames,
-
+  actions,
+  logo,
+  appTitle,
   children,
 }: PropAdminShell) {
   return (
     <>
-      <AdminShellTopnav navItems={navItems} />
-      {children}
+      <Flex>
+        <nav>
+          <AdminShellMainnav
+            logo={logo}
+            navItems={navItems}
+            appTitle={appTitle}
+          />
+        </nav>
+        {children}
+      </Flex>
     </>
   );
 }

--- a/packages/ui/src/layouts/AdminShell/AdminShell.type.ts
+++ b/packages/ui/src/layouts/AdminShell/AdminShell.type.ts
@@ -9,10 +9,6 @@ export type NavItem = {
   customRender?: React.ReactNode;
 };
 
-export type PropAdminShellTopnav = {
-  navItems: any[];
-};
-
 export type PropAdminShellMainnav = {
   logo: string;
   navItems: NavItem[];
@@ -24,6 +20,12 @@ export type PropAdminShellSubnav = {
   appTitle: string;
   active: NavItem;
 };
+
+export type PropAdminShellTopnav = {
+  moduleName: string;
+  actions?: React.ReactNode;
+} & PropAdminShellSubnav &
+  PropAdminShellMainnav;
 
 export type PropAdminShell = {
   classnames?: any;

--- a/packages/ui/src/layouts/AdminShell/AdminShell.type.ts
+++ b/packages/ui/src/layouts/AdminShell/AdminShell.type.ts
@@ -19,6 +19,12 @@ export type PropAdminShellMainnav = {
   appTitle: string;
 };
 
+export type PropAdminShellSubnav = {
+  navItems: NavItem[];
+  appTitle: string;
+  active: NavItem;
+};
+
 export type PropAdminShell = {
   classnames?: any;
   children: React.ReactNode;

--- a/packages/ui/src/layouts/AdminShell/AdminShell.type.ts
+++ b/packages/ui/src/layouts/AdminShell/AdminShell.type.ts
@@ -1,10 +1,26 @@
+export type NavItem = {
+  label?: string;
+  description?: string;
+  icon?: React.ReactNode;
+  url?: string;
+  children?: NavItem[];
+  roles: ("admin" | "guest" | "user")[];
+  horizontalLine?: boolean;
+  customRender?: React.ReactNode;
+};
+
 export type PropAdminShellTopnav = {
   navItems: any[];
 };
 
-export type PropAdminShell = {
-  //styles
-  classNames?: any;
+export type PropAdminShellMainnav = {
+  logo: string;
+  navItems: NavItem[];
+  appTitle: string;
+};
 
+export type PropAdminShell = {
+  classnames?: any;
   children: React.ReactNode;
-} & PropAdminShellTopnav;
+  actions?: React.ReactNode;
+} & PropAdminShellMainnav;

--- a/packages/ui/src/layouts/AdminShell/components/MainNav/AdminShell.Mainnav.tsx
+++ b/packages/ui/src/layouts/AdminShell/components/MainNav/AdminShell.Mainnav.tsx
@@ -1,0 +1,168 @@
+"use client";
+
+import {
+  Flex,
+  Tooltip,
+  UnstyledButton,
+  Avatar,
+  Drawer,
+  SimpleGrid,
+  Paper,
+  Stack,
+  Text,
+  Menu,
+} from "@mantine/core";
+import { useDisclosure } from "@mantine/hooks";
+import {
+  ArrowSquareInIcon,
+  PlaceholderIcon,
+  SignOutIcon,
+  UserIcon,
+} from "@phosphor-icons/react";
+import { usePathname } from "next/navigation";
+import Image from "next/image";
+import Link from "next/link";
+import React from "react";
+import { PropAdminShellMainnav } from "../../AdminShell.type";
+
+export function AdminShellMainnav({
+  logo,
+  navItems,
+  appTitle,
+}: PropAdminShellMainnav) {
+  const pathname = usePathname();
+  const [opened, { toggle }] = useDisclosure(false);
+  return (
+    <Flex
+      w={70}
+      h="100vh"
+      bg="backgroundPrimary"
+      direction="column"
+      justify="space-between"
+      align="center"
+      p={0}
+    >
+      <Flex direction="column" p={0} w="100%">
+        <Flex
+          w="100%"
+          justify="center"
+          align="center"
+          h={64}
+          style={{ borderBottom: "1px solid #343434" }}
+        >
+          <Link href="/">
+            <Tooltip label={appTitle} withArrow color="brand" position="right">
+              <Image src={logo} alt={appTitle} width={32} height={32} />
+            </Tooltip>
+          </Link>
+        </Flex>
+
+        <Flex direction="column" align="center" gap="lg" p="md">
+          {navItems.map((link) => (
+            <Tooltip
+              key={link.label}
+              label={link.label}
+              withArrow
+              position="right"
+              color="brand"
+            >
+              <Link
+                href={link.url || "#"}
+                passHref
+                style={{
+                  color: `${
+                    pathname.includes(link.url ?? "") ? "white" : "gray"
+                  }`,
+                }}
+              >
+                <UnstyledButton>
+                  {React.isValidElement(link.icon) ? (
+                    React.cloneElement(link.icon)
+                  ) : (
+                    <PlaceholderIcon size={24} />
+                  )}
+                </UnstyledButton>
+              </Link>
+            </Tooltip>
+          ))}
+        </Flex>
+      </Flex>
+
+      <Flex direction="column" align="center" gap="lg" p="md">
+        <Tooltip label="Modules" withArrow color="brand" onClick={toggle}>
+          <UnstyledButton>
+            <ArrowSquareInIcon size={24} color="white" />
+          </UnstyledButton>
+        </Tooltip>
+        <Menu>
+          <Menu.Target>
+            <UnstyledButton>
+              <Avatar radius="xl" variant="filled" color="brand">
+                AM
+              </Avatar>
+            </UnstyledButton>
+          </Menu.Target>
+          <Menu.Dropdown>
+            <Menu.Item leftSection={<UserIcon />}>Profile</Menu.Item>
+            <Menu.Item leftSection={<SignOutIcon color="red" />}>
+              Logout
+            </Menu.Item>
+          </Menu.Dropdown>
+        </Menu>
+      </Flex>
+      {opened && (
+        <Drawer
+          opened={opened}
+          onClose={toggle}
+          size="100%"
+          // offset={16}
+          title="Modules"
+          position="bottom"
+          transitionProps={{
+            transition: "rotate-left",
+            duration: 150,
+            timingFunction: "linear",
+          }}
+        >
+          <Flex direction="row" align="center" justify="center" p="md">
+            <SimpleGrid cols={{ base: 1, sm: 2 }} spacing="md">
+              {navItems.map((link) => (
+                <Paper
+                  key={link.label}
+                  radius="md"
+                  shadow="md"
+                  p="md"
+                  withBorder
+                  style={{
+                    cursor: "pointer",
+                  }}
+                >
+                  <Link
+                    href={link.url || "#"}
+                    passHref
+                    onClick={toggle}
+                    style={{ textDecoration: "none" }}
+                  >
+                    <Stack gap="md" align="center">
+                      {React.isValidElement(link.icon) ? (
+                        React.cloneElement(link.icon)
+                      ) : (
+                        <PlaceholderIcon size={24} />
+                      )}
+                      <Text fz="sm" fw={600} c="brand">
+                        {link.label}
+                      </Text>
+                      <Text fz="xs" c="dimmed">
+                        {link.description}
+                      </Text>
+                    </Stack>
+                  </Link>
+                </Paper>
+              ))}
+            </SimpleGrid>
+          </Flex>
+        </Drawer>
+      )}
+    </Flex>
+  );
+}

--- a/packages/ui/src/layouts/AdminShell/components/MainNav/index.ts
+++ b/packages/ui/src/layouts/AdminShell/components/MainNav/index.ts
@@ -1,0 +1,1 @@
+export { AdminShellMainnav } from "./AdminShell.Mainnav";

--- a/packages/ui/src/layouts/AdminShell/components/SubNav/AdminShell.Subnav.tsx
+++ b/packages/ui/src/layouts/AdminShell/components/SubNav/AdminShell.Subnav.tsx
@@ -1,0 +1,124 @@
+"use client";
+import { NavItem, PropAdminShellSubnav } from "../../AdminShell.type";
+import { usePathname } from "next/navigation";
+import { Divider, Box, NavLink, Text, Flex, ScrollArea } from "@mantine/core";
+import { CircleIcon } from "@phosphor-icons/react";
+import classes from "./AdminShellSubnav.module.css";
+export function AdminShellSubnav({
+  navItems,
+  appTitle,
+  active,
+}: PropAdminShellSubnav) {
+  const pathname = usePathname();
+  const renderNavItem = (link: NavItem, level = 0) => {
+    if (link.horizontalLine) {
+      return (
+        <Divider
+          key={`divider-${Math.random()}`}
+          my="md"
+          mx="md"
+          opacity={0.2}
+        />
+      );
+    }
+
+    if (link.label && !link.url && !link.children) {
+      return (
+        <Text
+          key={link.label}
+          fz="sm"
+          fw={600}
+          c="dimmed"
+          // mt="md"
+          style={{ paddingLeft: level * 16 }}
+        >
+          {link.label}
+        </Text>
+      );
+    }
+
+    if (link.label && link.children && !link.url) {
+      return (
+        <Box key={link.label}>
+          <NavLink
+            classNames={classes}
+            label={link.label}
+            leftSection={link.icon}
+            rightSection={link.customRender}
+            variant="filled"
+            px="md"
+            active={link.url === pathname}
+            c={link.url === pathname ? "white" : "dimmed"}
+            href={link.url}
+            style={{
+              paddingLeft: level * 16,
+              borderRadius: 0,
+              borderLeft: level > 0 ? "1px solid #343434" : undefined,
+            }}
+          >
+            {link.children.map((child) => renderNavItem(child, level + 1))}
+          </NavLink>
+        </Box>
+      );
+    }
+    return (
+      <NavLink
+        classNames={classes}
+        key={link.url}
+        label={link.label}
+        leftSection={link.icon}
+        rightSection={
+          link.url === pathname ? (
+            <CircleIcon weight="fill" size={8} />
+          ) : (
+            link.customRender
+          )
+        }
+        variant="filled"
+        px="md"
+        active={link.url === pathname}
+        c={link.url === pathname ? "white" : "dimmed"}
+        href={link.url}
+        style={{
+          paddingLeft: level * 16,
+          borderRadius: 0,
+          borderLeft: level > 0 ? "1px solid #343434" : undefined,
+        }}
+      />
+    );
+  };
+
+  return (
+    <ScrollArea w={300} h="100vh" bg="backgroundDeep">
+      <Flex direction="column">
+        <Flex
+          justify="space-between"
+          align="center"
+          p="md"
+          h={64}
+          style={{ borderBottom: "1px solid #343434" }}
+        >
+          <Text fz="lg" fw={500} c="white">
+            {appTitle}
+          </Text>
+          <Text fz="xs" c="white" opacity={0.5}>
+            v0.1.1
+          </Text>
+        </Flex>
+
+        <Flex direction="column" gap={0} p="md">
+          <Text fz="xl" c="white" fw={500}>
+            {active.label}
+          </Text>
+          <Text fz="xs" c="white" opacity={0.5}>
+            {active.description}
+          </Text>
+        </Flex>
+
+        <Flex direction="column">
+          {navItems.map((link) => renderNavItem(link))}
+        </Flex>
+      </Flex>
+    </ScrollArea>
+  );
+}

--- a/packages/ui/src/layouts/AdminShell/components/SubNav/AdminShellSubnav.module.css
+++ b/packages/ui/src/layouts/AdminShell/components/SubNav/AdminShellSubnav.module.css
@@ -1,0 +1,15 @@
+.root {
+  padding: 4px;
+}
+
+.label {
+  font-size: 12px !important;
+}
+
+.root:hover {
+  background-color: var(--mantine-color-brand-6);
+}
+
+.root:hover .label {
+  color: var(--mantine-color-white) !important;
+}

--- a/packages/ui/src/layouts/AdminShell/components/SubNav/index.ts
+++ b/packages/ui/src/layouts/AdminShell/components/SubNav/index.ts
@@ -1,0 +1,1 @@
+export { AdminShellSubnav } from "./AdminShell.Subnav";

--- a/packages/ui/src/layouts/AdminShell/components/Topnav/AdminShell.Topnav.tsx
+++ b/packages/ui/src/layouts/AdminShell/components/Topnav/AdminShell.Topnav.tsx
@@ -39,7 +39,7 @@ import classes from "./AdminShell.module.css";
 import { PropAdminShellTopnav } from "../../AdminShell.type";
 import { usePathname, useRouter } from "next/navigation";
 
-export function AdminShellTopnav({ navItems }: PropAdminShellTopnav) {
+export function AdminShellTopnav({}: PropAdminShellTopnav) {
   // * DEFINITIONS
 
   const Pathname = usePathname();

--- a/packages/ui/src/layouts/AdminShell/components/Topnav/AdminShell.Topnav.tsx
+++ b/packages/ui/src/layouts/AdminShell/components/Topnav/AdminShell.Topnav.tsx
@@ -4,100 +4,104 @@
 
 //mantine
 import {
-  ActionIcon,
-  Avatar,
-  Button,
-  Container,
-  Divider,
-  Grid,
+  Anchor,
+  Box,
+  Breadcrumbs,
+  Burger,
+  Drawer,
+  Flex,
   Group,
-  Menu,
-  Paper,
-  Space,
   Text,
-  ThemeIcon,
 } from "@mantine/core";
-//icons
-import {
-  BellIcon,
-  CaretDownIcon,
-  CheeseIcon,
-  CircleIcon,
-  DotsThreeVerticalIcon,
-  MagnifyingGlassIcon,
-  PawPrintIcon,
-  QuestionIcon,
-  SkullIcon,
-  SlidersHorizontalIcon,
-  XIcon,
-  YarnIcon,
-} from "@phosphor-icons/react";
+
+import { AdminShellMainnav } from "../MainNav";
+import { AdminShellSubnav } from "../SubNav";
 
 //styles
-import classes from "./AdminShell.module.css";
 //type
 import { PropAdminShellTopnav } from "../../AdminShell.type";
-import { usePathname, useRouter } from "next/navigation";
+import { useDisclosure } from "@mantine/hooks";
+import { useBreadcrumbContext } from "../../../../context/BreadcrumbContext";
+import { useBreadcrumbs } from "../../../../hooks/useBreadcrumbs";
 
-export function AdminShellTopnav({}: PropAdminShellTopnav) {
-  // * DEFINITIONS
+export function AdminShellTopnav({
+  actions,
+  active,
+  logo,
+  appTitle,
+  navItems,
+  moduleName,
+}: PropAdminShellTopnav) {
+  const { breadcrumbs: customCrumbs } = useBreadcrumbContext();
+  const defaultBreadcrumbs = useBreadcrumbs(navItems);
+  const breadcrumbs = customCrumbs ?? defaultBreadcrumbs;
+  const [opened, { toggle, close }] = useDisclosure(false);
 
-  const Pathname = usePathname();
-  const Router = useRouter();
-
-  // * CONTEXT
-
-  // * STATE
-
-  // * FUNCTIONS
-
-  // * COMPONENTS
-
-  // * ANIMATIONS
+  const subLinks = active?.children || [];
 
   return (
     <>
-      <header className={classes.root}>
-        <Paper bg="none" radius={0}>
-          <Container>
-            <Group justify="space-between">
-              <Group gap="xl" py={4}>
-                <Group py="xs" gap="4px">
-                  <PawPrintIcon
-                    size={12}
-                    weight="duotone"
-                    color="var(--mantine-color-brand-6)"
-                  />
-                  <Text size="sm">
-                    <b>lagom</b> airbnb.
-                  </Text>
-                </Group>
-
-                <Paper p="xs" withBorder>
-                  <Group gap="xs">
-                    <Avatar size="xs" radius="xs">
-                      M
-                    </Avatar>
-                    <Text size="xs">General Admin</Text>
-                    <CaretDownIcon />
-                  </Group>
-                </Paper>
-              </Group>
-
-              <Group gap="xs">
-                <Paper>
-                  <Group gap={0}>
-                    <Avatar />
-                    <ActionIcon size="xs">
-                      <CaretDownIcon />
-                    </ActionIcon>
-                  </Group>
-                </Paper>
-              </Group>
-            </Group>
-          </Container>
-        </Paper>
-      </header>
+      <Flex
+        w="100%"
+        justify="space-between"
+        align="center"
+        style={{
+          borderBottom: "1px solid #c7c7c7",
+        }}
+        h={64}
+      >
+        <Group p="md" gap="sm">
+          <Burger size="sm" hiddenFrom="md" onClick={toggle} opened={opened} />
+          <Text fz="lg" fw={500}>
+            {moduleName}
+          </Text>
+          <Breadcrumbs separatorMargin={0}>
+            {breadcrumbs.map((crumb, index) => (
+              <Anchor
+                key={crumb.label}
+                href={crumb.href}
+                size="xs"
+                c={index === breadcrumbs.length - 1 ? "dimmed" : "blue"}
+                underline="hover"
+              >
+                {crumb.label}
+              </Anchor>
+            ))}
+          </Breadcrumbs>
+        </Group>
+        <Box p="md">{actions}</Box>
+      </Flex>
+      <Drawer
+        opened={opened}
+        onClose={close}
+        withCloseButton={false}
+        size={370}
+        h="100vh"
+        overlayProps={{ blur: 2 }}
+        hiddenFrom="md"
+        styles={{
+          content: {
+            padding: 0,
+            margin: 0,
+          },
+          body: {
+            padding: 0,
+          },
+        }}
+      >
+        <Group align="start" gap={0} wrap="nowrap">
+          <AdminShellMainnav
+            logo={logo}
+            navItems={navItems}
+            appTitle={appTitle}
+          />
+          <AdminShellSubnav
+            navItems={subLinks}
+            active={active}
+            appTitle={appTitle}
+          />
+        </Group>
+      </Drawer>
     </>
   );
 }


### PR DESCRIPTION
This PR introduces the core navigation structure for the admin dashboard layout, including:

- **Main Navigation** (`MainNav`)
Vertical sidebar navigation with structured navigation items and support for section grouping and icons.

- **Sub Navigation** (`SubNav`)
Nested sidebar component showing contextual navigation based on the active main section, including deep nesting and visual hierarchy.

- **Top Navigation** (`TopNav`)
 Header bar with app title, version, and placeholder space for future actions or user controls.

**Features:**

- Responsive and theme-consistent layout using Mantine components.

- Dynamic rendering of nested links with indentation and conditional styling.

- Active route highlighting based on the current pathname.

- Organized structure to support future extensibility.

